### PR TITLE
Update with IMSS amendment (#17)

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -56,11 +56,11 @@ The name of the organization shall be Ruddock House.
 Each officer shall be a Full Member of the House when elected and during their term of office. If, during their term of office, their membership changes, they immediately forfeit their office.
 \subsection{Qualifications and Duties of Elected Officers}
 \begin{enumerate}
-\item The President shall reside in Ruddock House and shall be a junior or senior for the latter portion of their term in office. They shall represent the House on the Interhouse Committee, preside over House Meetings, be chairperson of the Executive Committee, and be an ex-officio member of all House committees, and shall be responsible for selecting Full Members to attend freshmen picks.
+\item The President shall reside in Ruddock House and shall be a junior or senior for the latter portion of their term in office. They shall represent the House on the Interhouse Committee, preside over House Meetings, be chairperson of the Executive Committee, and be an ex-officio member of all House committees, and shall be responsible for selecting Full Members to attend frosh picks.
 \item The Vice President shall be a junior or senior for the latter portion of their term in office. They shall assume the duties of the President in the event of the President’s absence. They shall be responsible for maintaining the external relations of the House, for bringing guests to the House, and shall act as official host for all House guests. They shall be the Ruddock representative on the Review Committee. They shall share duties with the Treasurer in maintaining house property.
 \item The Secretary shall record minutes, including all motions made and the votes on these by all officers present, of all House, Executive Committee, and Upper Class Committee meetings; and post publicly a copy of the minutes of all open meetings. They shall have custody of all House records not specifically delegated to the custody of another officer, and in general shall perform all the duties of a corresponding and recording secretary. They shall be responsible for room assignments.
 \item The Treasurer shall be responsible to the House for all receipts and expenditures, shall maintain an adequate book-keeping system, shall submit a report to the Executive Committee at each regularly scheduled meeting, shall propose a budget to the Executive Committee for each term, and shall submit to the House a written report of the finances at the end of each term. They shall share duties with the Vice President in maintaining house property.
-\item The Librarian shall reside in Ruddock House and shall be a sophomore for the latter portion of their term in office. They shall be responsible for procuring magazines and newspapers, and for maintaining the House Library, including its records. They shall publish a House list at the beginning of each term. They shall be responsible for freshman orientation and organizing the freshman members of the House for the performance of those tasks assigned to them.
+\item The Librarian shall reside in Ruddock House and shall be a sophomore for the latter portion of their term in office. They shall be responsible for procuring magazines and newspapers, and for maintaining the House Library, including its records. They shall publish a House list at the beginning of each term. They shall be responsible for frosh orientation and organizing the frosh members of the House for the performance of those tasks assigned to them.
 \item The office of Social Team shall be held by not more than five members of the House, among them a single Social Manager. The Social Team will be responsible for organizing social functions, and for publishing a calendar of such events.
 \item The office of Athletic Team shall be held by not more than three members of the House, among them a single Athletic Manager. The Athletic Team shall be responsible for all athletic equipment used by the House, for the participation of the House in Interhouse and intrahouse athletics, and in general shall organize and promote the athletic activities of the House.
 \item The office of Sophomore Representative shall be held by a sophomore for the latter portion of their term in office. They shall be responsible for representing the thoughts and ideas of the sophomore members of the House on the Executive Committee.
@@ -71,12 +71,19 @@ Each officer shall be a Full Member of the House when elected and during their t
 \subsection{Duties and Qualifications of Appointed Officers}
 \begin{enumerate}
 \item One Upper Class Committee-member shall reside in each Ruddock House Alley and two shall reside off-campus, except in the case where no suitable volunteers can be found living off-campus, in which case the Off-Campus Upper Class Committee-members may live on-campus. An Upper Class Committee-member shall have been both enrolled at Caltech for at least five academic terms and a Full House Member for at least three academic terms prior to their term of office. A Peer Advocate shall have been both enrolled at Caltech for at least five academic terms and a Full House Member for at least three academic terms prior to their term of office. They shall be available to counsel any member of the House, particularly the occupants of the alley in which they reside or, in the case of an Off-Campus Upper Class Committee-member, any off-campus member. They shall be responsible for maintaining order and enforcing the rules and policies of the House. They shall not concurrently be an Upper Class Committee-member and hold a position on the Executive Committee.
-\item The Head Upper Class Committee-member shall have all the qualifications and duties of an Upper Class Committee-member. They shall be the head and ex officio member of the Upper Class Committee. They shall be responsible for the entire freshman selection except for the duties delegated to the President. The Head Upper Class Committee-member shall have previously served as a Ruddock Upper Class Committee-member, except in the case where no suitable volunteers can be found.
+\item The Head Upper Class Committee-member shall have all the qualifications and duties of an Upper Class Committee-member. They shall be the head and ex officio member of the Upper Class Committee. They shall be responsible for the entire frosh selection except for the duties delegated to the President. The Head Upper Class Committee-member shall have previously served as a Ruddock Upper Class Committee-member, except in the case where no suitable volunteers can be found.
 \item The Diversity Councilmembers shall be responsible for liaising with the Caltech Center for Diversity. They shall be available to advise any member of the House on issues pertaining to diversity. They shall select one Representative to be present during the selection of the Upper Class Committee and the Diversity Council. This Representative may not reapply for a position on the succeeding Diversity Council. In the case where no suitable volunteers can be found, the Head Upper Class Committee-person shall act as a proxy for the Diversity Council during the selection of the Upper Class Committee and the Diversity Council.
 \item The Historians shall be responsible for all recording and preservation of House records and traditions, including House scrapbook, House history, and House roll, and for submission of the House article in the Institute yearbook.
 \item The Head Waiter shall be responsible for maintaining proper decorum and conduct in the dining room, and shall direct the student waiters.
 \item The House BFD Editors shall be responsible for publishing the House paper.
 \item The House O’Domhnaill’s Suppliers shall maintain the House convenience store.
+\item The House IMSS Representatives shall act as liaisons between House members and Information Management Systems and Services for network, application, hardware, and software problems. The IMSS Representatives shall include the following:
+\begin{enumerate}
+	\item The Lab Rat shall be responsible for the upkeep of computer lab computers, organization of computer lab supplies, and cleaning of the space.
+	\item The Printer Representative shall ensure that the House paper-and-ink printers are in working order for use by House members and coordinate with admin for replacement parts and supplies.
+	\item The 3D Printer Representative shall ensure that the House 3D printers are in working order for use by House members, procure House-provided 3D printer supplies, and maintain a usage policy for the printer and supplies.
+	\item The Webmaster shall be responsible for administration of the Ruddock web server and keeping the website (ruddock.caltech.edu) online.
+\end{enumerate}
 \end{enumerate}
 \subsection{Nominations, Elections, and Appointments}
 \begin{enumerate}
@@ -111,7 +118,7 @@ All members of the Executive Committee shall vote. Each office shall receive one
 \item The Executive Committee shall formulate House rules and policies, and assume all duties not otherwise delegated.
 \item It shall appoint all offices described under Section 2.3 of this Constitution.
 \item It shall designate associate members.
-\item It shall have the power of dismissal over all appointed officers, other than Upper Class Committeemen.
+\item It shall have the power of dismissal over all appointed officers, other than Upper Class Committee-members.
 \end{enumerate}
 \subsection{Meetings}
 \begin{enumerate}
@@ -137,7 +144,7 @@ The Upper Class Committee:
 \begin{enumerate}
 \item Meetings may be called by the Head Upper Class Committee-member, Resident Associate, or any two Upper Class Committee-members.
 \item The Head Upper Class Committee-member shall preside over Upper Class Committee meetings and shall vote only in the case of a tie.
-\item A quorum shall consist of at least 2/3 of the Upper Class Committeemen, provided that when the Committee considers the case of an individual person, the Upper Class Committee-member of the alley in which the person lives, and the Upper Class Committee-member of the alley in which the infraction occurred, must be present.
+\item A quorum shall consist of at least 2/3 of the Upper Class Committee-members, provided that when the Committee considers the case of an individual person, the Upper Class Committee-member of the alley in which the person lives, and the Upper Class Committee-member of the alley in which the infraction occurred, must be present.
 \end{enumerate}
 \section{House Meetings}
 \subsection{Meetings}
@@ -174,7 +181,7 @@ In case of a dispute on parliamentary procedure in meetings of the House or any 
 \item The dues for Associate Members shall be set by a majority vote of the Executive Committee.
 \end{enumerate}
 \subsection{Levies}
-The dues may be changed, or addition assessments levied, only by a 1/2 vote of the Full Membership.
+The dues may be changed, or additional assessments levied, only by a 1/2 vote of the Full Membership.
 \subsection{Payment of Moneys}
 \begin{enumerate}
 \item Checks and other instruments for the payment of moneys shall be drawn in the name of the House and shall be signed either by the President or by the Treasurer.
@@ -207,14 +214,6 @@ the Secretary, then
 \item partial occupancy of room capacity.
 \end{enumerate}
 \end{enumerate}
-\item Prior to the section 7.1.2a Room Hassle the Secretary shall designate an off-campus alley\footnote{The framers of this Constitution recommend 260 Chester as the designated off-campus alley.} for the members of the sophomore class. The residency shall be filled in the following manner:
-\begin{enumerate}
-\item intended number of occupants, then
-\item intended number of sophomore occupants, then
-\item sophomores’ office as specified in section 7.2.8, then
-\item sophomores’ random order prepared prior to the section 7.1.2a Room Hassle in a manner proscribed by the Secretary.
-\end{enumerate}
-\item In the event that no members of the sophomore class wish to reside within the off-campus alley, the standard pick order shall be used. 
 \item The Upper Class Committee shall arbitrate all conflicts and disputes.
 \item The Secretary may consolidate unoccupied beds if doing so will increase the number of occupants of the house.
 \end{enumerate}
@@ -229,7 +228,7 @@ the Secretary, then
 \item Entire rooms shall be guaranteed to the following officers:
 \begin{enumerate}
 \item In order of preference, President, Vice President, Secretary, Treasurer, Librarian, Social Team including the Social Manager (up to three members), Athletic Team including the Athletic Manager (up to two members), Head UCC, On Campus UCCs (one member per alley), Peer Advocates, IHC Chair, ASCIT President, BoC Chair, House-elected BoC Representatives (up to two members), O’Domhnaill’s Suppliers (up to two members), House Head Waiter (one member), House BFD editors (one member), House Historians (one member)
-\item for the entire academic year following the election or appointment provided the officer completes their term. If an officer quits their office mid-term, the room guarantee shall transfer to the succeeding officeholder for the remainder of the guarantee term.
+\item for the entire academic year following the election or appointment provided the officer completes their term. If an officer quits their office mid-term, the room guarantee shall transfer to the succeeding officeholder for the remainder of the guaranteed term.
 \end{enumerate}
 \item The officer room pick order shall be President, Vice President, Secretary, Treasurer, Librarian, Social Manager, Athletic Manager, Head UCC, On Campus UCCs, IHC Chair, ASCIT President, BoC Chair, Social Team, Athletic Team, House-elected BoC Representatives (up to two members), O’Domhnaill’s Suppliers (up to two members), House Head Waiter (one member), House BFD editors (one member), House Historians (one member).
 \item All Full Members who have picked into a room through a room hassle under 7.1.2a or 7.1.2b shall be guaranteed the same room upon their return from Study Abroad.
@@ -266,5 +265,5 @@ For the election of the BoC representatives, each voter may cast two first choic
 
 Proxy votes shall be submitted to a member of the Election Committee in written form prior to the election. The Election Committee shall be responsible for entering proxy votes during the election.
 
-The Election Committee shall hear the grievance of any Full House Member from the time of the election to 36 hours post. They shall have closed meetings to determine the legitimacy of the grievance and shall announce any solution to the House. If a solution cannot be reached by the Election Committee, then the election shall be rerun, in part or in full, in accordance with the nature of the grievance. If the grievance is regarding the persons on the Election Committee, then the Upperclassmen Committee shall hear the grievance. They shall have the powers to disband the Election Committee, force a redrawing of a new Election Committee, and begin the election process anew.
+The Election Committee shall hear the grievance of any Full House Member from the time of the election to 36 hours post. They shall have closed meetings to determine the legitimacy of the grievance and shall announce any solution to the House. If a solution cannot be reached by the Election Committee, then the election shall be rerun, in part or in full, in accordance with the nature of the grievance. If the grievance is regarding the persons on the Election Committee, then the Upper Class Committee shall hear the grievance. They shall have the powers to disband the Election Committee, force a redrawing of a new Election Committee, and begin the election process anew.
 \end{document}


### PR DESCRIPTION
* Add IMSS amendment

Adds language to create IMSS representatives in apointed positions. Passed 4/11/2020.

* Completes Gender Neutral Wording

Completes gender neutral wording. Passed 1/2019.
In particular, "committeemen" was changed to "committee-members" and "freshmen" was changed to "frosh."

* Completes Room Hassle ROCA amendment

Removes language regarding the sophomore off-campus alley approved by the Room Hassle ROCA Removal Update Amendment. Passed 03/19/2019.

Co-authored-by: mply <mply@users.noreply.github.com>